### PR TITLE
Fix for #14 - WorldGuard softcrash

### DIFF
--- a/src/main/java/de/helixdevs/deathchest/DeathChestPlugin.java
+++ b/src/main/java/de/helixdevs/deathchest/DeathChestPlugin.java
@@ -21,6 +21,8 @@ import org.bukkit.command.PluginCommand;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
@@ -77,7 +79,9 @@ public class DeathChestPlugin extends JavaPlugin implements Listener, DeathChest
 
     @Override
     public void onLoad() {
-        WorldGuardDeathChestFlag.register();
+        PluginManager pluginManager = Bukkit.getPluginManager();
+        Plugin plugin = pluginManager.getPlugin("WorldGuard");
+        if (plugin != null) { WorldGuardDeathChestFlag.register(); }
     }
 
     @Override

--- a/src/main/java/de/helixdevs/deathchest/util/WorldGuardDeathChestFlag.java
+++ b/src/main/java/de/helixdevs/deathchest/util/WorldGuardDeathChestFlag.java
@@ -2,24 +2,19 @@ package de.helixdevs.deathchest.util;
 
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.protection.flags.StateFlag;
-import org.bukkit.Bukkit;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.PluginManager;
 
 public final class WorldGuardDeathChestFlag {
 
     public static StateFlag FLAG;
 
-    public static void register() {
-        PluginManager pluginManager = Bukkit.getPluginManager();
-        Plugin plugin = pluginManager.getPlugin("WorldGuard");
-        if (plugin == null)
-            return;
-        WorldGuard instance = WorldGuard.getInstance();
-        if (instance == null)
-            return;
-        FLAG = new StateFlag("spawn-death-chest", false);
-        instance.getFlagRegistry().register(FLAG);
-    }
 
+    public static void register()
+    {
+        WorldGuard instance = WorldGuard.getInstance();
+        if (instance != null)
+        {
+            FLAG = new StateFlag("spawn-death-chest", false);
+            instance.getFlagRegistry().register(FLAG);
+        }
+    }
 }


### PR DESCRIPTION
This fixes the softcrash #14 that happens when the plugin is loaded with out the softdependency plugin WorldGuard being present.