### PR TITLE
optimized entity id helper

### DIFF
--- a/src/main/java/com/github/devcyntrix/deathchest/util/EntityIdHelper.java
+++ b/src/main/java/com/github/devcyntrix/deathchest/util/EntityIdHelper.java
@@ -7,26 +7,24 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class EntityIdHelper {
     private static AtomicInteger counter;
 
-    private static void initCounter() {
+    static {
         try {
             Class<?> entityClass = Class.forName("net.minecraft.world.entity.Entity");
             Field entityCounter = Arrays.stream(entityClass.getDeclaredFields())
                     .filter(field -> field.getType().equals(AtomicInteger.class))
                     .findFirst()
                     .orElse(null);
-            if (entityCounter == null)
-                return;
-            entityCounter.trySetAccessible();
-            counter = (AtomicInteger) entityCounter.get(null);
-        } catch (ClassNotFoundException | IllegalAccessException ignored) {
-        } finally {
-            if (counter == null) counter = new AtomicInteger();
+            if (entityCounter != null) {
+                entityCounter.trySetAccessible();
+                counter = (AtomicInteger) entityCounter.get(null);
+            }
+        } catch (Exception e) {
+            counter = new AtomicInteger();
+            e.printStackTrace();
         }
     }
 
     public static int increaseAndGet() {
-        if (counter == null)
-            initCounter();
         return counter.incrementAndGet();
     }
 }


### PR DESCRIPTION
Anstelle die Class und den Field zu speichern, speichere ich den AtomicInteger selbst.
Das spart Performance und beugt, im Falle, dass die Class oder der Field nicht existiert, unnötiges Error Handling vor.