### PR TITLE
set target and source compatibility for automatic jdk selection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_17
 }
 
 tasks {


### PR DESCRIPTION
Wenn man das Projekt frisch klont, hat man das Problem, dass keine JDK-Version ausgewählt ist
Diese PR behebt dieses Problem