### PR TITLE
Fix typo in plugin.yml resulting in incorrectly named permissions

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -39,4 +39,4 @@ permissions:
       - 'deathchest.command.deathchest'
       - 'deathchest.command.report'
       - 'deathchest.command.deleteInWorld'
-      - 'eathchest.command.reload'
+      - 'deathchest.command.reload'


### PR DESCRIPTION
Noticed while mucking about with LuckPerms that one of the permissions is missing the all important **d** in **deathchest**. Sorry for such a tiny pointless PR!